### PR TITLE
Updates

### DIFF
--- a/SOURCES/get_sources.sh
+++ b/SOURCES/get_sources.sh
@@ -9,8 +9,8 @@ pushd erlang; wget https://github.com/erlang/otp/archive/OTP-18.3.4.4.tar.gz; po
 pushd libkml; wget https://github.com/google/libkml/archive/release-1.2.tar.gz; popd
 pushd openjpeg2; wget https://github.com/uclouvain/openjpeg/archive/v2.1.2.tar.gz; popd
 pushd gdal; wget http://download.osgeo.org/gdal/2.1.2/gdal-2.1.2.tar.gz; popd
-pushd tomcat8; wget http://archive.apache.org/dist/tomcat/tomcat-8/v8.5.8/bin/apache-tomcat-8.5.8.tar.gz; popd
-pushd postgis; wget http://download.osgeo.org/postgis/source/postgis-2.3.0.tar.gz; popd
+pushd tomcat8; wget http://archive.apache.org/dist/tomcat/tomcat-8/v8.5.9/bin/apache-tomcat-8.5.9.tar.gz; popd
+pushd postgis; wget http://download.osgeo.org/postgis/source/postgis-2.3.1.tar.gz; popd
 if [ $version == 7 ];then
   pushd gdal; wget https://s3.amazonaws.com/yum-geonode.boundlessps.com/src/MrSID_DSDK-9.5.1.4427-linux.x86-64.gcc48.tar.gz; popd
 else

--- a/SOURCES/get_sources.sh
+++ b/SOURCES/get_sources.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-TODO: just download alls ources
+TODO: just download all sources
 echo 'downloading sources'
 echo '-------------------'
 
@@ -8,8 +8,8 @@ version=`rpm -qa \*-release | grep -Ei "redhat|centos" | cut -d"-" -f3`
 pushd erlang; wget https://github.com/erlang/otp/archive/OTP-18.3.4.4.tar.gz; popd
 pushd libkml; wget https://github.com/google/libkml/archive/release-1.2.tar.gz; popd
 pushd openjpeg2; wget https://github.com/uclouvain/openjpeg/archive/v2.1.2.tar.gz; popd
-pushd gdal; wget http://download.osgeo.org/gdal/2.0.3/gdal-2.0.3.tar.gz; popd
-pushd tomcat8; wget http://apache.mirror.rafal.ca/tomcat/tomcat-8/v8.5.6/bin/apache-tomcat-8.5.6.tar.gz; popd
+pushd gdal; wget http://download.osgeo.org/gdal/2.1.2/gdal-2.1.2.tar.gz; popd
+pushd tomcat8; wget http://archive.apache.org/dist/tomcat/tomcat-8/v8.5.8/bin/apache-tomcat-8.5.8.tar.gz; popd
 pushd postgis; wget http://download.osgeo.org/postgis/source/postgis-2.3.0.tar.gz; popd
 if [ $version == 7 ];then
   pushd gdal; wget https://s3.amazonaws.com/yum-geonode.boundlessps.com/src/MrSID_DSDK-9.5.1.4427-linux.x86-64.gcc48.tar.gz; popd

--- a/SOURCES/tomcat8/context.xml
+++ b/SOURCES/tomcat8/context.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+
+    <!-- Default set of monitored resources. If one of these changes, the    -->
+    <!-- web application will be reloaded.                                   -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+    <Resources cachingAllowed="true" cacheMaxSize="100000" />
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+</Context>

--- a/SOURCES/tomcat8/tomcat8.service
+++ b/SOURCES/tomcat8/tomcat8.service
@@ -1,0 +1,25 @@
+# Systemd unit file for tomcat8
+
+[Unit]
+Description=Apache Tomcat 8 Application
+After=syslog.target network.target
+
+[Service]
+Type=simple
+
+Environment="CATALINA_BASE=/usr/share/tomcat8"
+Environment="CATALINA_PID=$CATALINA_BASE/bin/tomcat.pid"
+Environment="JAVA_OPTS=-Djava.awt.headless=true -Xms256m -Xmx1024m -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:NewRatio=2"
+
+LimitNOFILE=65535
+
+ExecStart=/usr/share/tomcat8/bin/catalina.sh run >> /usr/share/tomcat8/logs/catalina.out 2>&1
+ExecStop=/usr/share/tomcat8/bin/catalina.sh stop >> /usr/share/tomcat8/logs/catalina.out 2>&1
+Restart=on-failure
+RestartSec=2
+
+User=tomcat
+Group=tomcat
+
+[Install]
+WantedBy=multi-user.target

--- a/SPECS/libkml.spec
+++ b/SPECS/libkml.spec
@@ -14,8 +14,10 @@ BuildRequires:	libcurl-devel
 BuildRequires:	expat-devel
 BuildRequires:	autoconf
 BuildRequires:	libtool
+%{?el6:BuildRequires: libgcj-devel}
+
 Requires:	expat, zlib, minizip
-%if %{?rhel} > 6
+%if 0%{?rhel} == 7
 Patch0: configure.ac.patch
 Patch1: file_posix.cc.patch
 Patch2: suffix.hpp.patch
@@ -40,7 +42,7 @@ using the LIBKML library.
 
 %prep
 %setup -q -n %{name}-release-%{version}
-%if %{?rhel} > 6
+%if 0%{?rhel} == 7
 %patch0 -p2
 %patch1 -p2
 %patch2 -p2

--- a/SPECS/postgis.spec
+++ b/SPECS/postgis.spec
@@ -1,10 +1,8 @@
-
-%define pgdir /usr/pgsql-9.5
+%define pgdir /usr/pgsql-9.6
 %define mver 2.3
-%define majorversion 23
 
 Summary:        Geographic Information Systems Extensions to PostgreSQL
-Name:           postgis
+Name:           postgis2-96
 Version:        2.3.0
 Release:        1%{?dist}
 License:        GPL v2
@@ -28,10 +26,10 @@ BuildRequires:  gtk2-devel
 BuildRequires:  gettext-devel
 BuildRequires:  perl
 BuildRequires:  gcc-c++ libxslt-devel dos2unix
-BuildRequires:  postgresql95-devel
+BuildRequires:  postgresql96-devel
 
 AutoReq:        no
-Requires:       postgresql95-libs
+Requires:       postgresql96-libs
 Requires:       geos >= 3.5.0
 Requires:       proj >= 4.8.0
 Requires:       gdal >= 2.0.1
@@ -45,16 +43,6 @@ allowing it to be used as a backend spatial database for geographic information
 systems (GIS), much like ESRI's SDE or Oracle's Spatial extension. PostGIS
 follows the OpenGIS "Simple Features Specification for SQL" and will be
 submitted for conformance testing at version 1.0.
-
-%package postgresql95
-Summary:        PostGIS for PostgreSQL 9.5
-Group:          Applications/Databases
-Requires:       %{name} = %{version}
-Requires:       postgresql95-server, json-c >= 0.11
-
-%description postgresql95
-The postgresql95 package provides the PostGIS server side libraries for
-PostgreSQL 9.5.
 
 #%package utils
 #Summary:        The utils for PostGIS
@@ -73,8 +61,7 @@ Requires:       %{name} = %{version} gtk2
 The postgis-gui package provides a graphical shapefile loader and dumper for PostGIS.
 
 %prep
-%setup -q
-
+%setup -q -n postgis-%{version}
 
 %build
 LDFLAGS=-L%{pgdir}/lib
@@ -144,8 +131,6 @@ rm -rf %{buildroot}
 %{_libdir}/*
 %{_includedir}/*
 %{_mandir}/*
-
-%files postgresql95
 %{pgdir}/lib/*
 %defattr(644,root,root)
 %{pgdir}/share/contrib/postgis-%{mver}/*
@@ -164,6 +149,8 @@ rm -rf %{buildroot}
 #%{pgdir}/bin/shp2pgsql-gui
 
 %changelog
+* Sat Nov 12 2016 amirahav <arahav@boundlessgeo.com> [2.3.0-1]
+- Bump to 2.3.0 and Postgres 9.6
 * Sun Apr 24 2016 amirahav <arahav@boundlessgeo.com> [2.2.2-1]
 - Updated to 2.2.2
 * Sat Jan 16 2016 amirahav <arahav@boundlessgeo.com> [2.2.1-1]

--- a/SPECS/postgis.spec
+++ b/SPECS/postgis.spec
@@ -3,7 +3,7 @@
 
 Summary:        Geographic Information Systems Extensions to PostgreSQL
 Name:           postgis2-96
-Version:        2.3.0
+Version:        2.3.1
 Release:        1%{?dist}
 License:        GPL v2
 Group:          Applications/Databases

--- a/SPECS/swig.spec
+++ b/SPECS/swig.spec
@@ -1,0 +1,56 @@
+%define ver 1.3.40
+%define prefix /usr
+%define home_page http://www.swig.org
+%define docprefix %{prefix}/share
+
+Summary: Simplified Wrapper and Interface Generator
+Name: swig
+Version: %{ver}
+Release: 1%{?dist}
+URL: %{home_page}
+Source0: %{name}-%{version}.tar.gz
+License: BSD
+Group: Development/Tools
+BuildRoot: %{_tmppath}/%{name}-root
+
+%define _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm
+%define _unpackaged_files_terminate_build 0
+
+%description
+SWIG is a software development tool that connects programs written in C and C++
+with a variety of high-level programming languages. SWIG is primarily used with
+common scripting languages such as Perl, Python, Tcl/Tk, and Ruby, however the
+list of supported languages also includes non-scripting languages such as Java,
+OCAML and C#. Also several interpreted and compiled Scheme implementations
+(Guile, MzScheme, Chicken) are supported. SWIG is most commonly used to create
+high-level interpreted or compiled programming environments, user interfaces,
+and as a tool for testing and prototyping C/C++ software. SWIG can also export
+its parse tree in the form of XML and Lisp s-expressions. 
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+# so we can build package from Git source too
+[ ! -r configure ] && ./autogen.sh
+%configure
+make
+
+%install
+rm -rf ${RPM_BUILD_ROOT}
+make DESTDIR=$RPM_BUILD_ROOT install
+
+%clean
+rm -rf ${RPM_BUILD_ROOT}
+
+%files
+%defattr(-,root,root)
+%doc ANNOUNCE CHANGES INSTALL LICENSE README
+%doc Doc/*
+%{_bindir}/*
+%{prefix}/share/*
+
+%changelog
+* Sat Feb 13 2016 amirahav <arahav@boundlessgeo.com>
+- Initial build
+

--- a/SPECS/tomcat8.spec
+++ b/SPECS/tomcat8.spec
@@ -8,7 +8,7 @@
 
 Summary:    Apache Servlet/JSP Engine, RI for Servlet 3.1/JSP 2.3 API
 Name:       tomcat8
-Version:    8.5.8
+Version:    8.5.9
 Release:    1
 License:    Apache Software License
 Group:      Networking/Daemons

--- a/SPECS/tomcat8.spec
+++ b/SPECS/tomcat8.spec
@@ -8,7 +8,7 @@
 
 Summary:    Apache Servlet/JSP Engine, RI for Servlet 3.1/JSP 2.3 API
 Name:       tomcat8
-Version:    8.5.6
+Version:    8.5.8
 Release:    1
 License:    Apache Software License
 Group:      Networking/Daemons
@@ -100,6 +100,7 @@ cd -
 
 # Put conf in /etc/ and link back.
 install -d -m 755 %{buildroot}/%{_sysconfdir}/%{name}/Catalina/localhost
+install -m 644 %_sourcedir/%{name}/context.xml %{buildroot}/%{tomcat_home}/conf/context.xml
 mv %{buildroot}/%{tomcat_home}/conf/* %{buildroot}/%{_sysconfdir}/%{name}/
 rmdir %{buildroot}/%{tomcat_home}/conf
 cd %{buildroot}/%{tomcat_home}/
@@ -130,6 +131,7 @@ install -d -m 755 %{buildroot}/usr/{bin,sbin}
 mv %{buildroot}/%{tomcat_home}/bin/digest.sh %{buildroot}/usr/bin/%{name}-digest
 mv %{buildroot}/%{tomcat_home}/bin/tool-wrapper.sh %{buildroot}/usr/bin/%{name}-tool-wrapper
 
+%if 0%{?rhel} == 6
 # Drop init script
 install -d -m 755 %{buildroot}/%{_initrddir}
 install    -m 755 %_sourcedir/%{name}.init %{buildroot}/%{_initrddir}/%{name}
@@ -137,6 +139,10 @@ install    -m 755 %_sourcedir/%{name}.init %{buildroot}/%{_initrddir}/%{name}
 # Drop sysconfig script
 install -d -m 755 %{buildroot}/%{_sysconfdir}/sysconfig/
 install    -m 644 %_sourcedir/%{name}.sysconfig %{buildroot}/%{_sysconfdir}/sysconfig/%{name}
+%else if 0%{?rhel} == 7
+install -d -m 755 %{buildroot}/%{_sysconfdir}/systemd/system
+install -m 644 %_sourcedir/%{name}/%{name}.service %{buildroot}/%{_sysconfdir}/systemd/system/%{name}.service
+%endif
 
 # Drop logrotate script
 install -d -m 755 %{buildroot}/%{_sysconfdir}/logrotate.d
@@ -158,9 +164,15 @@ getent passwd %{tomcat_user} >/dev/null || /usr/sbin/useradd --comment "Tomcat D
 %{tomcat_home}/*
 %attr(0755,root,root) /usr/bin/*
 %dir /var/lib/%{name}
+
+%if 0%{?rhel} == 6
 %{_initrddir}/%{name}
-%{_sysconfdir}/logrotate.d/%{name}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
+%else if 0%{?rhel} == 7
+%{_sysconfdir}/systemd/system/%{name}.service
+%endif
+
+%{_sysconfdir}/logrotate.d/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}
 %doc /usr/share/doc/%{name}-%{version}
 %defattr(0644,root,root,0755)
@@ -184,19 +196,33 @@ getent passwd %{tomcat_user} >/dev/null || /usr/sbin/useradd --comment "Tomcat D
 /var/lib/%{name}/webapps/ROOT
 
 %post
+%if 0%{?rhel} == 6
 chkconfig --add %{name}
+%else if 0%{?rhel} == 7
+systemctl daemon-reload
+%endif
 
 %preun
 if [ $1 = 0 ]; then
+  %if 0%{?rhel} == 6
   service %{name} stop > /dev/null 2>&1
   chkconfig --del %{name}
+  %else if 0%{?rhel} == 7
+  systemctl restart %{name} > /dev/null 2>&1
+  %endif
 fi
 
 %postun
 if [ $1 -ge 1 ]; then
-  service %{name} condrestart >/dev/null 2>&1
+  %if 0%{?rhel} == 6
+  service %{name} condrestart > /dev/null 2>&1
+  %else if 0%{?rhel} == 7
+  systemctl condrestart %{name} > /dev/null 2>&1
+  %endif
 fi
 
 %changelog
+* Sat Nov 12 2016 amirahav <arahav@boundlessgeo.com> [8.5.8-1]
+- Bump to 8.5.8
 * Thu Nov 03 2016 BerryDaniel <dberry@boundlessgeo.com> [8.5.6-1]
 - Updated to 8.5.6

--- a/SPECS/tomcat8.spec
+++ b/SPECS/tomcat8.spec
@@ -208,7 +208,7 @@ if [ $1 = 0 ]; then
   service %{name} stop > /dev/null 2>&1
   chkconfig --del %{name}
   %else if 0%{?rhel} == 7
-  systemctl restart %{name} > /dev/null 2>&1
+  systemctl stop %{name} > /dev/null 2>&1
   %endif
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 version=`rpm -qa \*-release | grep -Ei "redhat|centos" | cut -d"-" -f3`
 if [ $version == 7 ];then
+echo "[boundlessps]
+name=boundlessps
+baseurl=https://yum.boundlessps.com/el7/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.boundlessps.com/RPM-GPG-KEY-yum.boundlessps.com
+" > /etc/yum.repos.d/boundlessps.repo
+  rpm -ivh https://yum.postgresql.org/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
+  rpm -ivh https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
   sudo yum -y update
-  rpm -ivh http://yum.postgresql.org/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-2.noarch.rpm
   sudo yum -y install ant \
                  autoconf \
                  bzip2-devel \
@@ -37,20 +45,32 @@ if [ $version == 7 ];then
                  openssl-devel \
                  openldap-devel \
                  poppler-devel \
-                 postgresql95-devel \
+                 postgresql96-devel \
                  proj-devel \
                  readline-devel \
                  rpmdevtools \
                  sqlite-devel \
-                 swig \
+                 swig-1.3.40 \
                  tk-devel \
                  unzip \
                  xerces-c-devel \
                  zip \
-                 zlib-devel
+                 zlib-devel \
+                 zlib-devel \
+                 hdf5-devel \
+                 netcdf-devel
 
 else
-  curl -o /etc/yum.repos.d/exchange.repo https://yum.boundlessps.com/geoshape.repo
+echo "[boundlessps]
+name=boundlessps
+baseurl=https://yum.boundlessps.com/el6/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.boundlessps.com/RPM-GPG-KEY-yum.boundlessps.com
+" > /etc/yum.repos.d/boundlessps.repo
+
+  rpm -ivh https://yum.postgresql.org/9.6/redhat/rhel-6-x86_64/pgdg-centos96-9.6-3.noarch.rpm
+  rpm -ivh https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
   sudo yum -y update
   sudo yum -y install ant \
                  autoconf \
@@ -86,7 +106,7 @@ else
                  openssl-devel \
                  openldap-devel \
                  poppler-devel \
-                 postgresql95-devel \
+                 postgresql96-devel \
                  proj-devel \
                  readline-devel \
                  rpmdevtools \
@@ -96,7 +116,9 @@ else
                  unzip \
                  xerces-c-devel \
                  zip \
-                 zlib-devel
+                 zlib-devel \
+                 hdf5-devel \
+                 netcdf-devel
 fi
 
 pushd /vagrant/SOURCES

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -56,7 +56,6 @@ gpgkey=https://yum.boundlessps.com/RPM-GPG-KEY-yum.boundlessps.com
                  xerces-c-devel \
                  zip \
                  zlib-devel \
-                 zlib-devel \
                  hdf5-devel \
                  netcdf-devel
 


### PR DESCRIPTION
**GDAL**
- Move to 2.1.2 (We've been using 2.1.0 with Exchange since May)
- Use Postgres 9.6
- Add support for Netcdf/HDF5/Poppler
- Add the python package
- Add back SWIG version constraint for RHEL7 (At least with GS 2.9x/ GT 15.x will only work with SWIG 1.x)  

**Tomcat**
- Configure global resource cache to silence logs
- Use systemd for RHEL7

**PostGIS** 
- Use Postgres 9.6
- Change package naming to make it possible to have Postgres specif versions (eg **postgis2-96** instead of **postgis**)
